### PR TITLE
chore(scrollable | carousel): adds user provided spacing to be added in inner scale of scrollable

### DIFF
--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -198,6 +198,11 @@ pub trait Component: fmt::Debug {
         aabb
     }
 
+    /// Specifies spacing between its children
+    fn spacing(&self) -> Scale {
+        Scale::new(0.0, 0.0)
+    }
+
     // Event handlers
     /// Handle mouse click events. These events will only be sent if the mouse is over the Component.
     fn on_click(&mut self, _event: &mut Event<event::Click>) {}

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -506,10 +506,6 @@ impl<T: EventInput> Event<T> {
 impl Event<Drag> {
     /// The distance dragged, in physical coordinates.
     pub fn physical_delta(&self) -> Point {
-        println!(
-            "Event::TouchDrag mouse_position {:?} start_pos {:?}",
-            self.mouse_position, self.input.start_pos
-        );
         self.mouse_position - self.input.start_pos
     }
 
@@ -532,10 +528,6 @@ impl Event<Drag> {
 impl Event<TouchDrag> {
     /// The distance dragged, in physical coordinates.
     pub fn physical_delta(&self) -> Point {
-        println!(
-            "Event::TouchDrag touch_position {:?} start_pos {:?}",
-            self.touch_position, self.input.start_pos
-        );
         self.touch_position - self.input.start_pos
     }
 

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -569,6 +569,28 @@ impl Event<DragEnd> {
     }
 }
 
+impl Event<TouchDragEnd> {
+    /// The distance dragged, in physical coordinates.
+    pub fn physical_delta(&self) -> Point {
+        self.touch_position - self.input.start_pos
+    }
+
+    /// The distance dragged, in logical coordinates.
+    pub fn logical_delta(&self) -> Point {
+        self.physical_delta().unscale(self.scale_factor)
+    }
+
+    /// The distance dragged, but clamped to the current Node's [`AABB`], in physical coordinates.
+    pub fn bounded_physical_delta(&self) -> Point {
+        self.touch_position.clamp(self.current_physical_aabb()) - self.input.start_pos
+    }
+
+    /// The distance dragged, but clamped to the current Node's [`AABB`], in logical coordinates.
+    pub fn bounded_logical_delta(&self) -> Point {
+        self.bounded_physical_delta().unscale(self.scale_factor)
+    }
+}
+
 #[derive(Debug, Default, Copy, Clone)]
 pub(crate) struct MouseButtonsHeld {
     pub left: bool,

--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -930,6 +930,15 @@ impl super::node::Node {
             }
         }
 
+        if self.scrollable() {
+            children_size.width += Dimension::Px(
+                (self.component.spacing().width * (self.children.len() - 1) as f32).into(),
+            );
+            children_size.height += Dimension::Px(
+                (self.component.spacing().height * (self.children.len() - 1) as f32).into(),
+            );
+        }
+
         children_size
     }
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -128,6 +128,24 @@ impl Add<f32> for Scale {
     }
 }
 
+impl Div<f32> for Scale {
+    type Output = Self;
+
+    fn div(self, factor: f32) -> Self::Output {
+        Scale {
+            width: self.width / factor,
+            height: self.height / factor,
+        }
+    }
+}
+
+impl AddAssign for Scale {
+    fn add_assign(&mut self, rhs: Self) {
+        self.width += rhs.width;
+        self.height += rhs.height;
+    }
+}
+
 impl From<[f32; 2]> for Scale {
     fn from(p: [f32; 2]) -> Self {
         unsafe { mem::transmute(p) }

--- a/core/src/widgets/carousel.rs
+++ b/core/src/widgets/carousel.rs
@@ -15,9 +15,9 @@ pub struct CarouselItem {}
 
 #[derive(Debug, Default)]
 pub struct TransitionPositions {
-    from: Point,
-    to: Point,
-    velocity: f32,
+    pub from: Point,
+    pub to: Point,
+    pub velocity: f32,
 }
 
 #[derive(Debug, Default)]

--- a/core/src/widgets/mod.rs
+++ b/core/src/widgets/mod.rs
@@ -25,7 +25,7 @@ mod slider;
 pub use slider::Slider;
 
 mod carousel;
-pub use carousel::Carousel;
+pub use carousel::{Carousel, TransitionPositions};
 
 mod textbox;
 pub use textbox::{TextBox, TextBoxAction, TextBoxVariant};


### PR DESCRIPTION
1. adds user provided spacing to be added in inner scale of scrollable
Using this we have to provide spacing property only at parent(Carousel) level.
Inner scale of parent will be calculated based on the spacing given and number of children.