### PR TITLE
bug-fix(font-cache): Eliminated unwanted cloning of `cosmic_text::fontdb::Database` by passing it as a reference

### DIFF
--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -33,13 +33,13 @@ macro_rules! msg {
 
 /// Passed to [`Component#render`][Component#method.render], with context required for rendering.
 #[derive(Clone)]
-pub struct RenderContext {
+pub struct RenderContext<'a> {
     /// The `AABB` that contains the given [`Component`] instance.
     pub aabb: AABB,
     /// For scrollable Components (Components that return a `Some` value for [`#scroll_position`][Component#method.scroll_position]), this is the size of the child Nodes.
     pub inner_scale: Option<Scale>,
     /// The caches used by the renderer.
-    pub caches: Caches,
+    pub caches: Caches<'a>,
     /// The value previously returned by [`Component#render`][Component#method.render] of the given instance.
     pub prev_state: Option<Vec<Renderable>>,
     /// The scale factor of the current monitor. Renderables should be scaled by this value.

--- a/core/src/renderer/canvas.rs
+++ b/core/src/renderer/canvas.rs
@@ -91,7 +91,7 @@ pub fn load_assets_to_canvas(
 }
 
 pub struct CanvasRenderer {
-    fonts: cosmic_text::fontdb::Database,
+    fonts_cache: FontCache,
     text_renderer: TextRenderer,
     assets: HashMap<String, ImageId>,
     svgs: HashMap<String, SvgData>,
@@ -123,7 +123,7 @@ impl super::Renderer for CanvasRenderer {
         let loaded_svgs = load_svg_paths(svgs, fonts.clone());
 
         Self {
-            fonts: fonts.clone(),
+            fonts_cache: FontCache::new(fonts.clone()),
             text_renderer,
             assets: HashMap::new(),
             svgs: loaded_svgs,
@@ -197,10 +197,10 @@ impl super::Renderer for CanvasRenderer {
     }
 
     /// This default is provided for tests, it should be overridden
-    fn caches(&self) -> Caches {
+    fn caches(&mut self) -> Caches {
         // println!("caches()");
         Caches {
-            font: Arc::new(RwLock::new(FontCache::new(self.fonts.clone()))),
+            font: Arc::new(RwLock::new(&mut self.fonts_cache)),
         }
     }
 }

--- a/core/src/renderer/mod.rs
+++ b/core/src/renderer/mod.rs
@@ -23,9 +23,9 @@ use std::{
 
 /// The caches used by the Renderer. Passed to [`Component#render`][crate::Component#method.render] in a [`RenderContext`][crate::RenderContext].
 #[derive(Clone)]
-pub struct Caches {
+pub struct Caches<'a> {
     /// Font cache
-    pub font: Arc<RwLock<FontCache>>,
+    pub font: Arc<RwLock<&'a mut FontCache>>,
 }
 
 pub trait RendererContext {}
@@ -37,5 +37,5 @@ pub(crate) trait Renderer: fmt::Debug + std::marker::Sized + Send + Sync {
     fn resize(&mut self, width: u32, height: u32) {}
     // use this method to clear any saved references or caches
     fn clear(&mut self) {}
-    fn caches(&self) -> Caches;
+    fn caches(&mut self) -> Caches;
 }

--- a/core/src/ui.rs
+++ b/core/src/ui.rs
@@ -200,14 +200,14 @@ impl<
                         new.view(Some(&mut old), &mut new_registrations);
                         *registrations.write().unwrap() = new_registrations;
 
-                        let renderer = renderer.read().unwrap();
+                        let mut renderer = renderer.write().unwrap();
 
                         if renderer.is_none() {
                             *node_dirty.write().unwrap() = true;
                             return;
                         }
 
-                        let caches: crate::renderer::Caches = renderer.as_ref().unwrap().caches();
+                        let caches: crate::renderer::Caches = renderer.as_mut().unwrap().caches();
 
                         new.layout(&old, &mut caches.font.write().unwrap(), scale_factor);
 

--- a/core/src/ui.rs
+++ b/core/src/ui.rs
@@ -209,6 +209,8 @@ impl<
 
                         let caches: crate::renderer::Caches = renderer.as_mut().unwrap().caches();
 
+                        // A mutable reference to caches to cache the properties that are
+                        // dynamically allocated by the nodes or componenets.
                         new.layout(&old, &mut caches.font.write().unwrap(), scale_factor);
 
                         do_render = new.render(caches, Some(&mut old), scale_factor);


### PR DESCRIPTION
# Objective
Fixes #70 

## Solution

`cosmic_test::fontdb::Database` was being cloned which was fixed by passing the `FontCache` itself as a mutable reference and making the changes accordingly.

### Before

```rust
    fn caches(&self) -> Caches {
        Caches {
            font: Arc::new(RwLock::new(FontCache::new(self.fonts.clone()))),
        }
    }
```
### After

```rust
    fn caches(&mut self) -> Caches {
        Caches {
            font: Arc::new(RwLock::new(&mut self.fonts_cache)),
        }
    }
```

## Testing

Flamegraph of the code after the fix

![image](https://github.com/user-attachments/assets/d395023f-7f15-4bbe-970e-60003b58821a)

